### PR TITLE
hsize_t[] parameters instead of hsize_t*

### DIFF
--- a/HDF5/H5Spublic.cs
+++ b/HDF5/H5Spublic.cs
@@ -205,7 +205,9 @@ namespace HDF.PInvoke
             CallingConvention = CallingConvention.Cdecl),
         SuppressUnmanagedCodeSecurity, SecuritySafeCritical]
         public static extern hid_t create_simple
-            (int rank, hsize_t* dims, hsize_t* maxdims);
+            (int rank, 
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]hsize_t[] dims, 
+            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]hsize_t[] maxdims);
 
         /// <summary>
         /// Decode a binary object description of data space and return a new
@@ -393,7 +395,9 @@ namespace HDF.PInvoke
             CallingConvention = CallingConvention.Cdecl),
         SuppressUnmanagedCodeSecurity, SecuritySafeCritical]
         public static extern int get_simple_extent_dims
-            (hid_t space_id, hsize_t* dims, hsize_t* maxdims);
+            (hid_t space_id, 
+            [MarshalAs(UnmanagedType.LPArray)]hsize_t[] dims, 
+            [MarshalAs(UnmanagedType.LPArray)]hsize_t[] maxdims);
 
         /// <summary>
         /// Determines the dimensionality of a dataspace.

--- a/UnitTests/H5STest/H5Screate_simple.cs
+++ b/UnitTests/H5STest/H5Screate_simple.cs
@@ -30,16 +30,8 @@ namespace UnitTests
         public void H5Screate_simpleTest1()
         {
             hsize_t[] dims = { 1, 2, 3 };
-            hid_t space = -1;
+            hid_t space =  H5S.create_simple(dims.Length, dims, dims);
 
-            unsafe
-            {
-                fixed (hsize_t* ptr = dims)
-                {
-                    space = H5S.create_simple(dims.Length, ptr, ptr);
-                }
-            }
-             
             Assert.IsTrue(space > 0);
             Assert.IsTrue(H5S.close(space) >= 0);
         }
@@ -48,15 +40,7 @@ namespace UnitTests
         public void H5Screate_simpleTest2()
         {
             hsize_t[] dims = { 1, 2, 3 };
-            hid_t space = -1;
-
-            unsafe
-            {
-                fixed (hsize_t* ptr = dims)
-                {
-                    space = H5S.create_simple(dims.Length, ptr, null);
-                }
-            }
+            hid_t space = H5S.create_simple(dims.Length, dims, dims);
 
             Assert.IsTrue(space > 0);
             Assert.IsTrue(H5S.close(space) >= 0);
@@ -66,15 +50,7 @@ namespace UnitTests
         public void H5Screate_simpleTest3()
         {
             hsize_t[] dims = { 1, 2, 3, 0 };
-            hid_t space = -1;
-
-            unsafe
-            {
-                fixed (hsize_t* ptr = dims)
-                {
-                    space = H5S.create_simple(dims.Length, ptr, null);
-                }
-            }
+            hid_t space = H5S.create_simple(dims.Length, dims, dims);
 
             Assert.IsTrue(space > 0);
             Assert.IsTrue(H5S.close(space) >= 0);
@@ -85,18 +61,7 @@ namespace UnitTests
         {
             hsize_t[] dims = { 1, 2, 3 };
             hsize_t[] max_dims = { H5S.UNLIMITED, H5S.UNLIMITED, H5S.UNLIMITED };
-            hid_t space = -1;
-
-            unsafe
-            {
-                fixed (hsize_t* ptr = dims)
-                {
-                    fixed (hsize_t* max_ptr = max_dims)
-                    {
-                        space = H5S.create_simple(dims.Length, ptr, max_ptr);
-                    }
-                }
-            }
+            hid_t space = H5S.create_simple(dims.Length, dims, max_dims);
 
             Assert.IsTrue(space > 0);
             Assert.IsTrue(H5S.close(space) >= 0);
@@ -107,18 +72,7 @@ namespace UnitTests
         {
             hsize_t[] dims = { 1, 2, 3, 0 };
             hsize_t[] max_dims = { 1, H5S.UNLIMITED, 3, 0 };
-            hid_t space = -1;
-
-            unsafe
-            {
-                fixed (hsize_t* ptr = dims)
-                {
-                    fixed (hsize_t* max_ptr = max_dims)
-                    {
-                        space = H5S.create_simple(dims.Length, ptr, max_ptr);
-                    }
-                }
-            }
+            hid_t space = H5S.create_simple(dims.Length, dims, max_dims);
 
             Assert.IsTrue(space > 0);
             Assert.IsTrue(H5S.close(space) >= 0);

--- a/UnitTests/H5STest/H5Sget_simple_extent_dims.cs
+++ b/UnitTests/H5STest/H5Sget_simple_extent_dims.cs
@@ -31,25 +31,21 @@ namespace UnitTests
         {
             hsize_t[] dims = { 1, 2, 3 };
             hid_t space = -1;
+            hsize_t[] dims_out = new hsize_t[3];
 
-            unsafe
-            {
-                fixed (hsize_t* ptr = dims)
-                {
-                    space = H5S.create_simple(dims.Length, ptr, ptr);
+            space = H5S.create_simple(dims.Length, dims, dims);
+            Assert.IsTrue(
+                H5S.get_simple_extent_dims(space, null, null) == 3);
 
-                    Assert.IsTrue(
-                        H5S.get_simple_extent_dims(space, null, null) == 3);
+            Assert.IsTrue(
+                H5S.get_simple_extent_dims(space, dims_out, null) == 3);
 
-                    Assert.IsTrue(
-                        H5S.get_simple_extent_dims(space, ptr, null) == 3);
-                    Assert.IsTrue(dims[2] == 3);
+            Assert.IsTrue(dims_out[2] == 3);
 
-                    Assert.IsTrue(
-                        H5S.get_simple_extent_dims(space, null, ptr) == 3);
-                    Assert.IsTrue(dims[0] == 1);
-                }
-            }
+            Assert.IsTrue(
+                H5S.get_simple_extent_dims(space, null, dims_out) == 3);
+
+            Assert.IsTrue(dims_out[0] == 1);
 
             Assert.IsTrue(space > 0);
             Assert.IsTrue(H5S.close(space) >= 0);
@@ -61,27 +57,19 @@ namespace UnitTests
             hsize_t[] dims = { 1, 2, 3 };
             hsize_t[] max_dims = { H5S.UNLIMITED, H5S.UNLIMITED, H5S.UNLIMITED };
             hid_t space = -1;
+            hsize_t[] dims_out = new hsize_t[3];
 
-            unsafe
-            {
-                fixed (hsize_t* ptr = dims)
-                {
-                    fixed (hsize_t* max_ptr = max_dims)
-                    {
-                        space = H5S.create_simple(dims.Length, ptr, max_ptr);
-                    }
-                    Assert.IsTrue(
-                    H5S.get_simple_extent_dims(space, null, null) == 3);
+            space = H5S.create_simple(dims.Length, dims, max_dims);
+            Assert.IsTrue(
+            H5S.get_simple_extent_dims(space, null, null) == 3);
 
-                    Assert.IsTrue(
-                        H5S.get_simple_extent_dims(space, ptr, null) == 3);
-                    Assert.IsTrue(dims[0] == 1);
+            Assert.IsTrue(
+                H5S.get_simple_extent_dims(space, dims_out, null) == 3);
+            Assert.IsTrue(dims_out[0] == 1);
 
-                    Assert.IsTrue(
-                        H5S.get_simple_extent_dims(space, null, ptr) == 3);
-                    Assert.IsTrue(dims[0] == H5S.UNLIMITED);
-                }
-            }
+            Assert.IsTrue(
+                H5S.get_simple_extent_dims(space, null, dims_out) == 3);
+            Assert.IsTrue(dims_out[0] == H5S.UNLIMITED);
 
             Assert.IsTrue(space > 0);
             Assert.IsTrue(H5S.close(space) >= 0);


### PR DESCRIPTION
for H5S create_simple/get_simple_extents_dims, the functions can be called with managed arrays instead of unsafe/fixed pointers
