### PR TITLE
Static Constructors for all classes

### DIFF
--- a/HDF5/H5ACpublic.cs
+++ b/HDF5/H5ACpublic.cs
@@ -22,6 +22,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5AC
     {
+        static H5AC() { H5.open(); }
+
         public const int CURR_CACHE_CONFIG_VERSION = 1;
 
         public const int MAX_TRACE_FILE_NAME_LEN = 1024;

--- a/HDF5/H5Apublic.cs
+++ b/HDF5/H5Apublic.cs
@@ -38,6 +38,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5A
     {
+        static H5A() { H5.open(); }
+
         /// <summary>
         /// Information struct for attribute
         /// (for H5Aget_info/H5Aget_info_by_idx)

--- a/HDF5/H5Cpublic.cs
+++ b/HDF5/H5Cpublic.cs
@@ -17,6 +17,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5C
     {
+        static H5C() { H5.open(); }
+
         public enum cache_incr_mode
         {
             OFF,

--- a/HDF5/H5DOpublic.cs
+++ b/HDF5/H5DOpublic.cs
@@ -32,6 +32,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5DO
     {
+        static H5DO() { H5.open(); }
+
         /// <summary>
         /// Writes a raw data chunk from a buffer directly to a dataset.
         /// See https://www.hdfgroup.org/HDF5/doc/HL/RM_HDF5Optimized.html

--- a/HDF5/H5Dpublic.cs
+++ b/HDF5/H5Dpublic.cs
@@ -35,6 +35,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5D
     {
+        static H5D() { H5.open(); }
+
         public readonly size_t CACHE_NSLOTS_DEFAULT = new IntPtr(-1);
         public readonly size_t CACHE_NBYTES_DEFAULT = new IntPtr(-1);
         public const float CACHE_W0_DEFAULT = -1.0f;

--- a/HDF5/H5Epublic.cs
+++ b/HDF5/H5Epublic.cs
@@ -36,6 +36,7 @@ namespace HDF.PInvoke
     {
         static H5E()
         {
+            H5.open();
             m_importer = H5DLLImporter.Create();
         }
 

--- a/HDF5/H5FDpublic.cs
+++ b/HDF5/H5FDpublic.cs
@@ -25,6 +25,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5FD
     {
+        static H5FD() { H5.open(); }
+
         /// <summary>
         /// Define enum for the source of file image callbacks
         /// </summary>

--- a/HDF5/H5Fpublic.cs
+++ b/HDF5/H5Fpublic.cs
@@ -38,6 +38,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5F
     {
+        static H5F() { H5.open(); }
+
         // Flags for H5F.open() and H5F.create() calls
 
         /// <summary>

--- a/HDF5/H5Gpublic.cs
+++ b/HDF5/H5Gpublic.cs
@@ -31,6 +31,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5G
     {
+        static H5G() { H5.open(); }
+
         /// <summary>
         /// Types of link storage for groups
         /// </summary>

--- a/HDF5/H5Ipublic.cs
+++ b/HDF5/H5Ipublic.cs
@@ -35,6 +35,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5I
     {
+        static H5I() { H5.open(); }
+
         public enum type_t
         {
             /// <summary>

--- a/HDF5/H5Lpublic.cs
+++ b/HDF5/H5Lpublic.cs
@@ -37,6 +37,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5L
     {
+        static H5L() { H5.open(); }
+
         /// <summary>
         /// Maximum length of a link's name
         /// (encoded in a 32-bit unsigned integer: 4GB - 1)

--- a/HDF5/H5Opublic.cs
+++ b/HDF5/H5Opublic.cs
@@ -37,6 +37,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5O
     {
+        static H5O() { H5.open(); }
+
         #region Flags for object copy (H5Ocopy)
 
         /// <summary>

--- a/HDF5/H5PLpublic.cs
+++ b/HDF5/H5PLpublic.cs
@@ -23,6 +23,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5PL
     {
+        static H5PL() { H5.open(); }
+
         public const int FILTER_PLUGIN = 0x0001;
 
         public const int ALL_PLUGIN = 0xffff;

--- a/HDF5/H5Ppublic.cs
+++ b/HDF5/H5Ppublic.cs
@@ -46,6 +46,7 @@ namespace HDF.PInvoke
     {
         static H5P()
         {
+            H5.open();
             m_importer = H5DLLImporter.Create();
         }
 

--- a/HDF5/H5Rpublic.cs
+++ b/HDF5/H5Rpublic.cs
@@ -35,6 +35,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5R
     {
+        static H5R() { H5.open(); }
+
         /// <summary>
         /// Reference types allowed.
         /// </summary>

--- a/HDF5/H5Spublic.cs
+++ b/HDF5/H5Spublic.cs
@@ -33,6 +33,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5S
     {
+        static H5S() { H5.open(); }
+
         // Define atomic datatypes
         public const int ALL = 0;
         public const hsize_t UNLIMITED = unchecked((hsize_t)(-1));

--- a/HDF5/H5Tpublic.cs
+++ b/HDF5/H5Tpublic.cs
@@ -36,6 +36,7 @@ namespace HDF.PInvoke
     {
         static H5T()
         {
+            H5.open();
             m_importer = H5DLLImporter.Create();
         }
 

--- a/HDF5/H5Zpublic.cs
+++ b/HDF5/H5Zpublic.cs
@@ -32,6 +32,8 @@ namespace HDF.PInvoke
 {
     public unsafe sealed class H5Z
     {
+        static H5Z() { H5.open(); }
+
         /// <summary>
         /// Filter IDs
         /// </summary>

--- a/UnitTests/_AssemblySpecific.cs
+++ b/UnitTests/_AssemblySpecific.cs
@@ -22,12 +22,12 @@ namespace UnitTests
     [TestClass]
     public class _AssemblySpecific
     {
-        [AssemblyInitialize()]
-        public static void AssemblyInit(TestContext context)
-        {
-            // open the HDF5 library
-            Assert.IsTrue(H5.open() >= 0);
-        }
+        //[AssemblyInitialize()]
+        //public static void AssemblyInit(TestContext context)
+        //{
+        //    // open the HDF5 library
+        //    Assert.IsTrue(H5.open() >= 0);
+        //}
 
         [AssemblyCleanup()]
         public static void AssemblyCleanup()


### PR DESCRIPTION
Each static constructor calls H5.open. No cleanup (i.e. H5.close()) is done yet. See #30 