### PR TITLE
Updates for HDF5 1.8.17

### DIFF
--- a/HDF5/H5Ppublic.cs
+++ b/HDF5/H5Ppublic.cs
@@ -681,15 +681,23 @@ namespace HDF.PInvoke
         SuppressUnmanagedCodeSecurity, SecuritySafeCritical]
         public static extern H5Z.EDC_t get_edc_check(hid_t plist);
 
-#if HDF5_VER1_10
-
+        /// <summary>
+        /// Retrieves the prefix for external raw data storage files as set in
+        /// the dataset access property list.
+        /// See https://www.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-GetEfilePrefix
+        /// </summary>
+        /// <param name="dapl">Dataset access property list identifier.</param>
+        /// <param name="prefix">Dataset external storage prefix.</param>
+        /// <param name="size">Size of prefix buffer in bytes.</param>
+        /// <returns>Returns the size of <paramref name="prefix"/> and the
+        /// prefix string will be stored in <paramref name="prefix"/> if
+        /// successful. Otherwise returns a negative value and the contents of
+        /// <paramref name="prefix"/> will be undefined.</returns>
         [DllImport(Constants.DLLFileName, EntryPoint = "H5Pget_efile_prefix",
             CallingConvention = CallingConvention.Cdecl),
         SuppressUnmanagedCodeSecurity, SecuritySafeCritical]
         public static extern ssize_t get_efile_prefix
-            (hid_t dapl_id, byte[] prefix, size_t size);
-
-#endif
+            (hid_t dapl, [Out] byte[] prefix, size_t size);
 
         /// <summary>
         /// Retrieves the external link traversal file access flag from the
@@ -2203,15 +2211,22 @@ namespace HDF.PInvoke
         public static extern herr_t set_edc_check
             (hid_t plist, H5Z.EDC_t check);
 
-#if HDF5_VER1_10
-
+        /// <summary>
+        /// Sets the external dataset storage file prefix in the dataset access
+        /// property list.
+        /// See https://www.hdfgroup.org/HDF5/doc/RM/RM_H5P.html#Property-SetEfilePrefix
+        /// </summary>
+        /// <param name="dapl">Dataset access property list identifier.</param>
+        /// <param name="prefix">Dataset external storage prefix.</param>
+        /// <returns>Returns a non-negative value if successful;
+        /// otherwise returns a negative value.</returns>
+        /// /// <remarks>ASCII strings ONLY!</remarks>
         [DllImport(Constants.DLLFileName, EntryPoint = "H5Pset_efile_prefix",
+            CharSet = CharSet.Ansi,
             CallingConvention = CallingConvention.Cdecl),
         SuppressUnmanagedCodeSecurity, SecuritySafeCritical]
         public static extern herr_t set_efile_prefix
-            (hid_t dapl_id, byte[] prefix);
-
-#endif
+            (hid_t dapl, string prefix);
 
         /// <summary>
         /// Sets the external link traversal file access flag in a link access

--- a/NuGet/HDF.PInvoke.1.8.17.nuspec
+++ b/NuGet/HDF.PInvoke.1.8.17.nuspec
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>HDF.PInvoke</id>
+        <version>1.8.17.1</version>
+        <summary>Raw HDF5 Power for .NET</summary>
+        <authors>The HDF Group</authors>
+        <owners>The HDF Group</owners>
+        <licenseUrl>http://www.hdfgroup.org/ftp/HDF5/current/src/unpacked/COPYING</licenseUrl>
+        <iconUrl>https://raw.githubusercontent.com/HDFGroup/HDF.PInvoke/master/images/hdf.png</iconUrl>
+        <projectUrl>https://github.com/HDFGroup/HDF.PInvoke</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+	<description>This package contains PInvoke declarations for the (unmanaged) HDF5 1.8.x C-API. For documenation, see the "HDF5: API Specification Reference Manual" at http://www.hdfgroup.org/HDF5/doc/RM/RM_H5Front.html .</description>
+        <copyright>Copyright 2016</copyright>
+        <language>en-US</language>
+        <tags>HDF5</tags>
+    </metadata>
+    <files>
+        <file src="C:\lib\hdf5-1.8.17\HDF.PInvoke.dll" target="lib\Net45\HDF.PInvoke.dll" />
+        <file src="C:\lib\hdf5-1.8.17\HDF.PInvoke.XML" target="lib\Net45\HDF.PInvoke.XML" />
+        <file src="C:\bin\bin32\hdf5-1.8.17\hdf5.dll" target="lib\native\bin32\hdf5.dll" />
+        <file src="C:\bin\bin32\hdf5-1.8.17\hdf5_hl.dll" target="lib\native\bin32\hdf5_hl.dll" />
+        <file src="C:\bin\bin32\hdf5-1.8.17\szip.dll" target="lib\native\bin32\szip.dll" />
+        <file src="C:\bin\bin32\hdf5-1.8.17\zlib.dll" target="lib\native\bin32\zlib.dll" />
+        <file src="C:\bin\bin64\hdf5-1.8.17\hdf5.dll" target="lib\native\bin64\hdf5.dll" />
+        <file src="C:\bin\bin64\hdf5-1.8.17\hdf5_hl.dll" target="lib\native\bin64\hdf5_hl.dll" />
+        <file src="C:\bin\bin64\hdf5-1.8.17\szip.dll" target="lib\native\bin64\szip.dll" />
+        <file src="C:\bin\bin64\hdf5-1.8.17\zlib.dll" target="lib\native\bin64\zlib.dll" />
+        <file src=".\tools\GetHDFPostBuildCmd.ps1" target="tools\GetHDFPostBuildCmd.ps1" />
+        <file src=".\tools\Install.ps1" target="tools\Install.ps1" />
+    </files>
+</package>

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -40,6 +40,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.10.0.*")]
 [assembly: AssemblyFileVersion("1.10.0.*")]
 #else
-[assembly: AssemblyVersion("1.8.16.*")]
-[assembly: AssemblyFileVersion("1.8.16.*")]
+[assembly: AssemblyVersion("1.8.17.*")]
+[assembly: AssemblyFileVersion("1.8.17.*")]
 #endif


### PR DESCRIPTION
Tested with HDF5 1.8.17. The `H5[g,s]et_efile_prefix` calls are present, and have been added. (I thought they came only with 1.10.0)