### PR TITLE
Include the native C/C++ in the NuGet packages.

### DIFF
--- a/NuGet/HDF.PInvoke.1.10.0.nuspec
+++ b/NuGet/HDF.PInvoke.1.10.0.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>HDF.PInvoke</id>
-        <version>1.10.0.1</version>
+        <version>1.10.0.2</version>
         <summary>Raw HDF5 Power for .NET</summary>
         <authors>The HDF Group</authors>
         <owners>The HDF Group</owners>
@@ -21,10 +21,14 @@
         <file src="D:\lib\hdf5-1.10.0\HDF.PInvoke.XML" target="lib\Net45\HDF.PInvoke.XML" />
         <file src="D:\bin\bin32\hdf5-1.10.0\hdf5.dll" target="lib\native\bin32\hdf5.dll" />
         <file src="D:\bin\bin32\hdf5-1.10.0\hdf5_hl.dll" target="lib\native\bin32\hdf5_hl.dll" />
+        <file src="D:\bin\bin32\hdf5-1.10.0\msvcp120.dll" target="lib\native\bin32\msvcp120.dll" />
+        <file src="D:\bin\bin32\hdf5-1.10.0\msvcr120.dll" target="lib\native\bin32\msvcr120.dll" />
         <file src="D:\bin\bin32\hdf5-1.10.0\szip.dll" target="lib\native\bin32\szip.dll" />
         <file src="D:\bin\bin32\hdf5-1.10.0\zlib.dll" target="lib\native\bin32\zlib.dll" />
         <file src="D:\bin\bin64\hdf5-1.10.0\hdf5.dll" target="lib\native\bin64\hdf5.dll" />
         <file src="D:\bin\bin64\hdf5-1.10.0\hdf5_hl.dll" target="lib\native\bin64\hdf5_hl.dll" />
+        <file src="D:\bin\bin64\hdf5-1.10.0\msvcp120.dll" target="lib\native\bin64\msvcp120.dll" />
+        <file src="D:\bin\bin64\hdf5-1.10.0\msvcr120.dll" target="lib\native\bin64\msvcr120.dll" />
         <file src="D:\bin\bin64\hdf5-1.10.0\szip.dll" target="lib\native\bin64\szip.dll" />
         <file src="D:\bin\bin64\hdf5-1.10.0\zlib.dll" target="lib\native\bin64\zlib.dll" />
         <file src=".\tools\GetHDFPostBuildCmd.ps1" target="tools\GetHDFPostBuildCmd.ps1" />

--- a/NuGet/HDF.PInvoke.1.8.17.nuspec
+++ b/NuGet/HDF.PInvoke.1.8.17.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>HDF.PInvoke</id>
-        <version>1.8.17.4</version>
+        <version>1.8.17.6</version>
         <summary>Raw HDF5 Power for .NET</summary>
         <authors>The HDF Group</authors>
         <owners>The HDF Group</owners>
@@ -21,10 +21,14 @@
         <file src="D:\lib\hdf5-1.8.17\HDF.PInvoke.XML" target="lib\Net45\HDF.PInvoke.XML" />
         <file src="D:\bin\bin32\hdf5-1.8.17\hdf5.dll" target="lib\native\bin32\hdf5.dll" />
         <file src="D:\bin\bin32\hdf5-1.8.17\hdf5_hl.dll" target="lib\native\bin32\hdf5_hl.dll" />
+        <file src="D:\bin\bin32\hdf5-1.8.17\msvcp120.dll" target="lib\native\bin32\msvcp120.dll" />
+        <file src="D:\bin\bin32\hdf5-1.8.17\msvcr120.dll" target="lib\native\bin32\msvcr120.dll" />
         <file src="D:\bin\bin32\hdf5-1.8.17\szip.dll" target="lib\native\bin32\szip.dll" />
         <file src="D:\bin\bin32\hdf5-1.8.17\zlib.dll" target="lib\native\bin32\zlib.dll" />
         <file src="D:\bin\bin64\hdf5-1.8.17\hdf5.dll" target="lib\native\bin64\hdf5.dll" />
         <file src="D:\bin\bin64\hdf5-1.8.17\hdf5_hl.dll" target="lib\native\bin64\hdf5_hl.dll" />
+        <file src="D:\bin\bin64\hdf5-1.8.17\msvcp120.dll" target="lib\native\bin64\msvcp120.dll" />
+        <file src="D:\bin\bin64\hdf5-1.8.17\msvcr120.dll" target="lib\native\bin64\msvcr120.dll" />
         <file src="D:\bin\bin64\hdf5-1.8.17\szip.dll" target="lib\native\bin64\szip.dll" />
         <file src="D:\bin\bin64\hdf5-1.8.17\zlib.dll" target="lib\native\bin64\zlib.dll" />
         <file src=".\tools\GetHDFPostBuildCmd.ps1" target="tools\GetHDFPostBuildCmd.ps1" />

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -38,8 +38,8 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 #if HDF5_VER1_10
 [assembly: AssemblyVersion("1.10.0.0")]
-[assembly: AssemblyFileVersion("1.10.0.1")]
+[assembly: AssemblyFileVersion("1.10.0.2")]
 #else
 [assembly: AssemblyVersion("1.8.17.0")]
-[assembly: AssemblyFileVersion("1.8.17.4")]
+[assembly: AssemblyFileVersion("1.8.17.6")]
 #endif


### PR DESCRIPTION
I forgot to include the native DLLs in the NuGet packages. I re-rolled them and updated the assembly file versions in line with our numbering scheme.