### PR TITLE
Move to .Net 2.0

### DIFF
--- a/HDF.PInvoke.csproj
+++ b/HDF.PInvoke.csproj
@@ -104,10 +104,6 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="HDF.PInvoke.snk" />
-    <None Include="HDF5\H5Eglobals.csv" />
-    <None Include="HDF5\H5Pglobals.csv" />
-    <None Include="HDF5\H5Tglobals.csv" />
-    <None Include="HDF5\H5Tglobal_aliases.csv" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="BeforeBuild">

--- a/HDF.PInvoke.csproj
+++ b/HDF.PInvoke.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>HDF.PInvoke</RootNamespace>
     <AssemblyName>HDF.PInvoke</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -68,12 +69,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="HDF5\Constants.cs" />

--- a/HDF.PInvoke.sln
+++ b/HDF.PInvoke.sln
@@ -10,6 +10,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{61BEF385-FA05-40BC-B09B-1318B9D06215}"
 	ProjectSection(SolutionItems) = preProject
 		paket.dependencies = paket.dependencies
+		paket.lock = paket.lock
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".project", ".project", "{FD3E97A7-0D4F-4634-A9DC-E6ABE370731E}"

--- a/HDF5/H5DLLImporter.cs
+++ b/HDF5/H5DLLImporter.cs
@@ -25,6 +25,8 @@ using hid_t = System.Int32;
 
 namespace HDF.PInvoke
 {
+    internal delegate T Converter<T>( IntPtr address );
+
     /// <summary>
     /// Helper class used to fetch public variables (e.g. native type values)
     /// exported by the HDF5 DLL

--- a/HDF5/NativeDependencies.cs
+++ b/HDF5/NativeDependencies.cs
@@ -78,7 +78,7 @@ namespace HDF.PInvoke
                 string EnvPath = Environment.GetEnvironmentVariable("PATH");
                 if (EnvPath.Contains(aPath)) return;
                 
-                Environment.SetEnvironmentVariable("PATH", $"{aPath};{EnvPath}");
+                Environment.SetEnvironmentVariable("PATH", aPath + ";" + EnvPath);
 
 
                 System.Diagnostics.Trace.WriteLine(string.Format(

--- a/HDF5/NativeDependencies.cs
+++ b/HDF5/NativeDependencies.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace HDF.PInvoke
 {    
@@ -38,8 +32,12 @@ namespace HDF.PInvoke
                     AppSettings[NativePathSetting].ToString();
                 if (string.IsNullOrEmpty(pathFromAppSettings))
                     return false;
-                if (Path.GetInvalidPathChars().Any(
-                    c => pathFromAppSettings.Contains(c))) return false;
+
+                foreach (var c in Path.GetInvalidPathChars())
+                {
+                    if (pathFromAppSettings.Contains( new string(c, 1) ))
+                        return false;
+                }
 
                 aPath = pathFromAppSettings;
                 return true;
@@ -60,15 +58,16 @@ namespace HDF.PInvoke
 
         private static void GetDllPathFromAssembly(out string aPath)
         {
-            if (Environment.Is64BitProcess)
+            switch (IntPtr.Size)
             {
-                aPath = Path.Combine(Path.GetDirectoryName(GetAssemblyName())
-                    , Constants.DLL64bitPath);
-            }
-            else
-            {
-                aPath = Path.Combine(Path.GetDirectoryName(GetAssemblyName())
-                    , Constants.DLL32bitPath);
+            case 8:
+                aPath = Path.Combine(Path.GetDirectoryName(GetAssemblyName()), Constants.DLL64bitPath);
+                break;
+            case 4:
+                aPath = Path.Combine(Path.GetDirectoryName(GetAssemblyName()), Constants.DLL32bitPath);
+                break;
+            default:
+                throw new NotImplementedException();
             }
         }
 
@@ -79,9 +78,9 @@ namespace HDF.PInvoke
                 string EnvPath = Environment.GetEnvironmentVariable("PATH");
                 if (EnvPath.Contains(aPath)) return;
                 
-                Environment.SetEnvironmentVariable
-                    ("PATH", string.Join(";", aPath, EnvPath));
-                    
+                Environment.SetEnvironmentVariable("PATH", $"{aPath};{EnvPath}");
+
+
                 System.Diagnostics.Trace.WriteLine(string.Format(
                     "{0} added to Path.", aPath));
             }

--- a/app.config
+++ b/app.config
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
     </configSections>
   <appSettings>
    <!--<add key ="NativeDependenciesAbsolutePath" value="C:\Program Files (x86)\HDF_Group\HDF5\1.8.17\bin" />-->
   </appSettings>
-</configuration>
+<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>

--- a/build.fsx
+++ b/build.fsx
@@ -16,7 +16,7 @@ let VER =
         let ver =
             let sv = (Seq.head allReleaseNotes).SemVer
             sprintf "%i.%i" sv.Major sv.Minor
-        tracefn "Auto choosed version: %s" ver
+        tracefn "Using version: %s" ver
         ver
 
 let name = sprintf "HDF5 %s" VER
@@ -136,3 +136,4 @@ Target "Rebuild" DoNothing
 
 RunTargetOrDefault "Test"
 
+logfn "RELEASE NOTES VERSION: %s" releaseNotes.NugetVersion


### PR DESCRIPTION
#101

> Would be beneficial to support .Net 2.0. There are only a few .Net 4.5 convenience features in use.
> Also problems like the one in #100 wouldn't occur.
> 
> I made the required modifications for .Net 2.0 on this branch
