### PR TITLE
Getting the native path from app settings can fail with NullReferenceException

### DIFF
--- a/HDF5/NativeDependencies.cs
+++ b/HDF5/NativeDependencies.cs
@@ -27,9 +27,7 @@ namespace HDF.PInvoke
             aPath = string.Empty;
             try
             {
-                if (ConfigurationManager.AppSettings.Count <= 0) return false;
-                string pathFromAppSettings = ConfigurationManager.
-                    AppSettings[NativePathSetting].ToString();
+                string pathFromAppSettings = ConfigurationManager.AppSettings[NativePathSetting];
                 if (string.IsNullOrEmpty(pathFromAppSettings))
                     return false;
 


### PR DESCRIPTION
See #112 for details.

`ConfigurationManger.AppSettings[ ... ]`:
* returns `null` when the key doesn't exist
* the return type is `string`, so the `ToString()` doesn't do anything except throwing throwing `NullReferenceException`