### PR TITLE
Fixed documentation comment of H5A.get_type

### DIFF
--- a/HDF5/H5Apublic.cs
+++ b/HDF5/H5Apublic.cs
@@ -628,7 +628,7 @@ namespace HDF.PInvoke
         public extern static hsize_t get_storage_size(hid_t attr_id);
 
         /// <summary>
-        /// Returns the amount of storage required for an attribute.
+        /// Retrieves a copy of the datatype for an attribute.
         /// See https://www.hdfgroup.org/HDF5/doc/RM/RM_H5A.html#Annot-GetType
         /// </summary>
         /// <param name="attr_id">Identifier of an attribute.</param>


### PR DESCRIPTION
The documentation comment of `H5A.get_type` seems incorrect:
https://github.com/HDFGroup/HDF.PInvoke/blob/d281aa75f1562e677d1307cc1a234f9079cd76c3/HDF5/H5Apublic.cs#L628-L641

Fix it according to: https://portal.hdfgroup.org/display/HDF5/H5A_GET_TYPE