### PR TITLE
Fixed entry point of H5Iget_type_ref

### DIFF
--- a/HDF5/H5Ipublic.cs
+++ b/HDF5/H5Ipublic.cs
@@ -253,10 +253,10 @@ namespace HDF.PInvoke
         /// is to be retrieved</param>
         /// <returns>Returns the current reference count on success, negative
         /// on failure.</returns>
-        [DllImport(Constants.DLLFileName, EntryPoint = "H5Iget_type",
+        [DllImport(Constants.DLLFileName, EntryPoint = "H5Iget_type_ref",
             CallingConvention = CallingConvention.Cdecl),
         SuppressUnmanagedCodeSecurity, SecuritySafeCritical]
-        public extern static int H5Iget_type_ref(type_t type);
+        public extern static int get_type_ref(type_t type);
 
         /// <summary>
         /// Increments the reference count for an object.


### PR DESCRIPTION
And rename `H5Iget_type_ref` to `get_type_ref`.