### PR TITLE
Cleaning up portal/support links

### DIFF
--- a/HDF5/H5Fpublic.cs
+++ b/HDF5/H5Fpublic.cs
@@ -8,8 +8,7 @@
  * the files COPYING and Copyright.html.  COPYING can be found at the root   *
  * of the source code distribution tree; Copyright.html can be found at the  *
  * root level of an installed copy of the electronic HDF5 document set and   *
- * is linked from the top-level documents page.  It can also be found at     *
- * http://hdfgroup.org/HDF5/doc/Copyright.html.  If you do not have          *
+ * is linked from the top-level documents page.  If you do not have          *
  * access to either file, you may request a copy from help@hdfgroup.org.     *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
@@ -570,7 +569,7 @@ namespace HDF.PInvoke
 #if HDF5_VER1_10
         /// <summary>
         /// Retrieves the setting for whether or not a file will create minimized dataset object headers.
-        /// See https://portal.hdfgroup.org/display/HDF5/H5F_GET_DSET_NO_ATTRS_HINT
+        /// See https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html#gaceb86e903eddc57846c8a249ab5b0a66
         /// </summary>
         /// <param name="file_id">File identifier</param>
         /// <param name="minimize">Flag indicating whether the library will or will not
@@ -586,7 +585,7 @@ namespace HDF.PInvoke
 
         /// <summary>
         /// Retrieves a copy of the image of an existing, open file.
-        /// See https://www.hdfgroup.org/HDF5/doc/RM/RM_H5F.html#File-GetFileImage
+        /// See https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html#gaadcc5da2bf8778217f32c8afc39c811e
         /// </summary>
         /// <param name="file_id">Target file identifier</param>
         /// <param name="buf_ptr">Pointer to the buffer into which the image of
@@ -603,7 +602,7 @@ namespace HDF.PInvoke
 
         /// <summary>
         /// Returns the size of an HDF5 file.
-        /// See https://www.hdfgroup.org/HDF5/doc/RM/RM_H5F.html#File-GetFilesize
+        /// See https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html#gabb3cb7870d5cabb5e5ebc6d00e160eb0
         /// </summary>
         /// <param name="file_id">Identifier of a currently-open HDF5
         /// file</param>
@@ -621,6 +620,7 @@ namespace HDF.PInvoke
         /// <summary>
         /// Retrieves free-space section information for a file.
         /// See https://www.hdfgroup.org/HDF5/docNewFeatures/FileSpace/H5Fget_free_sections.htm
+        /// HELP! I can't find this.
         /// </summary>
         /// <param name="file_id">Identifier of a currently-open HDF5
         /// file</param>
@@ -641,7 +641,7 @@ namespace HDF.PInvoke
 
         /// <summary>
         /// Returns the amount of free space in a file.
-        /// See https://www.hdfgroup.org/HDF5/doc/RM/RM_H5F.html#File-GetFreespace
+        /// See https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html#ga657d74efad7a6c99140ee15b38495cc6
         /// </summary>
         /// <param name="file_id">Identifier of a currently-open HDF5
         /// file</param>
@@ -654,7 +654,7 @@ namespace HDF.PInvoke
 
         /// <summary>
         /// Returns global information for a file.
-        /// See https://www.hdfgroup.org/HDF5/doc/RM/RM_H5F.html#File-GetInfo
+        /// See https://support.hdfgroup.org/documentation/hdf5/latest/group___f_h5_f.html#ga1b95a395f594fdf83021447f68f01e72
         /// </summary>
         /// <param name="obj_id">Object identifier for any object in the
         /// file.</param>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # What it is (not)
 
 HDF.PInvoke is a collection of [PInvoke](https://en.wikipedia.org/wiki/Platform_Invocation_Services)
-signatures for the [HDF5 C-API](https://docs.hdfgroup.org/hdf5/develop/).
+signatures for the [HDF5 C-API](https://support.hdfgroup.org/documentation/hdf5/latest/).
 It's practically *code-free*, which means we can blame all the bugs on Microsoft or [The HDF Group](https://www.hdfgroup.org/) :smile:
 
 It is **not** a high-level .NET interface for HDF5. "It's the [GCD](https://en.wikipedia.org/wiki/Greatest_common_divisor)
@@ -14,8 +14,8 @@ of .NET bindings for HDF5, not the [LCM](https://en.wikipedia.org/wiki/Least_com
 
 | HDF5 Release Version                                                   | Assembly Version | Assembly File Version | Git Tag |
 | ---------------------------------------------------------------------- | ---------------- | --------------------------------------------------------------- | ------- |
-| [1.8.21](https://portal.hdfgroup.org/downloads/index.html)  | 1.8.21.1         | [1.8.21.1](https://www.nuget.org/packages/HDF.PInvoke/1.8.21.1) | v1.8.21.1  |
-| [1.10.11](https://portal.hdfgroup.org/downloads/index.html) | 1.10.11         | [1.10.11](https://www.nuget.org/packages/HDF.PInvoke/1.10.11) | v1.10.11 |
+| [1.8.21](https://support.hdfgroup.org/downloads/index.html)  | 1.8.21.1         | [1.8.21.1](https://www.nuget.org/packages/HDF.PInvoke/1.8.21.1) | v1.8.21.1  |
+| [1.10.11](https://support.hdfgroup.org/downloads/index.html) | 1.10.11         | [1.10.11](https://www.nuget.org/packages/HDF.PInvoke/1.10.11) | v1.10.11 |
 
 [How "stuff" is versioned.](../../wiki/Versioning-and-Releases)
 
@@ -70,7 +70,7 @@ The HDF Group currently maintains **one** major HDF5 release family, HDF5 1.14. 
 HDF.PInvoke is part of [HDF5](https://www.hdfgroup.org/HDF5/). It is subject to
 the *same* terms and conditions as HDF5. Please review [COPYING](COPYING) or
 [https://www.hdfgroup.org/licenses/](https://www.hdfgroup.org/licenses/)
-for the details. If you have any questions, please [contact us](https://www.hdfgroup.org/about/contact.html).
+for the details. If you have any questions, please [contact us](https://www.hdfgroup.org/contact-us/).
 
 # Supporting HDF.PInvoke
 

--- a/build.fsx
+++ b/build.fsx
@@ -89,7 +89,7 @@ Target "GenTemplate" (fun _ ->
             Language = Some "en-US"
             Description =
                 [
-                """This package contains PInvoke declarations for the (unmanaged) HDF5 """ + VER + """.x C-API. For documenation, see the "Core Libray" at https://portal.hdfgroup.org/display/HDF5/Core+Library."""
+                """This package contains PInvoke declarations for the (unmanaged) HDF5 """ + VER + """.x C-API. For documenation, see the "Core Library" at https://support.hdfgroup.org/documentation/hdf5/latest/_r_m.html."""
                 ]
             Owners = ["The HDF Group"]
             Authors =


### PR DESCRIPTION
The readme in this repo is causing 404 links going to old portal and confluence links from the readme. I fixed the readme. There are many more reference manual links throughout the code but we'd need to decide if that was worth the investment to fix.